### PR TITLE
Remove unneeded constraints on IxContT instances

### DIFF
--- a/Control/Monad/Indexed/Cont.hs
+++ b/Control/Monad/Indexed/Cont.hs
@@ -45,10 +45,10 @@ instance IxFunctor (IxContT m) where
 instance IxPointed (IxContT m) where
   ireturn a = IxContT ($a)
 
-instance Monad m => IxApplicative (IxContT m) where
+instance IxApplicative (IxContT m) where
   iap = iapIxMonad
 
-instance Monad m => IxMonad (IxContT m) where
+instance IxMonad (IxContT m) where
   ibind f c = IxContT $ \k -> runIxContT c $ \a -> runIxContT (f a) k
 
 instance Monad m => IxMonadCont (IxContT m) where
@@ -73,17 +73,17 @@ callCC f = shift (\k -> f (adapt k) >>>= k)
     adapt k x = k x >>>= escape
     escape x = IxContT (\_k -> return x)
 
-instance Monad m => Functor (IxContT m i j) where
+instance Functor (IxContT m i j) where
   fmap = imap
 
-instance Monad m => Pointed (IxContT m i i) where
+instance Pointed (IxContT m i i) where
   point = ireturn
 
-instance Monad m => Applicative (IxContT m i i) where
+instance Applicative (IxContT m i i) where
   pure = ireturn
   (<*>) = iap
 
-instance Monad m => Monad (IxContT m i i) where
+instance Monad (IxContT m i i) where
   return = ireturn
   m >>= k = ibind k m
 

--- a/Control/Monad/Indexed/Cont.hs
+++ b/Control/Monad/Indexed/Cont.hs
@@ -8,6 +8,7 @@
 -- Stability   : experimental
 -- Portability : rank-2 Types required for correctness of shift, but they can be removed
 -------------------------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
 module Control.Monad.Indexed.Cont
   ( IxMonadCont(reset, shift)
   , IxContT(IxContT, runIxContT)
@@ -17,7 +18,9 @@ module Control.Monad.Indexed.Cont
   , runIxCont_
   ) where
 
+#if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
+#endif
 import Data.Pointed
 import qualified Control.Monad.Cont as Cont
 import Control.Monad.Identity

--- a/Control/Monad/Indexed/Cont.hs
+++ b/Control/Monad/Indexed/Cont.hs
@@ -1,21 +1,21 @@
 -------------------------------------------------------------------------------------------
 -- |
--- Module	: Control.Monad.Indexed.Cont
--- Copyright 	: 2008 Edward Kmett, Dan Doel
--- License	: BSD
+-- Module      : Control.Monad.Indexed.Cont
+-- Copyright   : 2008 Edward Kmett, Dan Doel
+-- License     : BSD
 --
--- Maintainer	: Reiner Pope <reiner.pope@gmail.com>
--- Stability	: experimental
--- Portability	: rank-2 Types required for correctness of shift, but they can be removed
+-- Maintainer  : Reiner Pope <reiner.pope@gmail.com>
+-- Stability   : experimental
+-- Portability : rank-2 Types required for correctness of shift, but they can be removed
 -------------------------------------------------------------------------------------------
-module Control.Monad.Indexed.Cont 
-	( IxMonadCont(reset, shift)
-	, IxContT(IxContT, runIxContT)
-	, runIxContT_
-	, IxCont(IxCont)
-	, runIxCont
-	, runIxCont_
-	) where
+module Control.Monad.Indexed.Cont
+  ( IxMonadCont(reset, shift)
+  , IxContT(IxContT, runIxContT)
+  , runIxContT_
+  , IxCont(IxCont)
+  , runIxCont
+  , runIxCont_
+  ) where
 
 import Control.Applicative
 import Data.Pointed
@@ -27,110 +27,110 @@ import Control.Monad.Reader
 import Control.Monad.Indexed.Trans
 
 class IxMonad m => IxMonadCont m where
-	reset :: m a o o -> m r r a
-	shift :: ((forall i. a -> m i i o) -> m r j j) -> m r o a
---	shift :: ((a -> m i i o) -> m r j j) -> m r o a
+  reset :: m a o o -> m r r a
+  shift :: ((forall i. a -> m i i o) -> m r j j) -> m r o a
+-- shift :: ((a -> m i i o) -> m r j j) -> m r o a
 
 newtype IxContT m r o a = IxContT { runIxContT :: (a -> m o) -> m r }
 
-runIxContT_ :: Monad m => IxContT m r a a -> m r 
+runIxContT_ :: Monad m => IxContT m r a a -> m r
 runIxContT_ m = runIxContT m return
 
 instance IxFunctor (IxContT m) where
-	imap f m = IxContT $ \c -> runIxContT m (c . f)
+  imap f m = IxContT $ \c -> runIxContT m (c . f)
 
 instance IxPointed (IxContT m) where
-	ireturn a = IxContT ($a)
+  ireturn a = IxContT ($a)
 
 instance Monad m => IxApplicative (IxContT m) where
-	iap = iapIxMonad
+  iap = iapIxMonad
 
 instance Monad m => IxMonad (IxContT m) where
-	ibind f c = IxContT $ \k -> runIxContT c $ \a -> runIxContT (f a) k
+  ibind f c = IxContT $ \k -> runIxContT c $ \a -> runIxContT (f a) k
 
 instance Monad m => IxMonadCont (IxContT m) where
-	reset e = IxContT $ \k -> runIxContT e return >>= k
-	shift e = IxContT $ \k -> e (\a -> IxContT (\k' -> k a >>= k')) `runIxContT` return
+  reset e = IxContT $ \k -> runIxContT e return >>= k
+  shift e = IxContT $ \k -> e (\a -> IxContT (\k' -> k a >>= k')) `runIxContT` return
 
 callCC :: Monad m => ((forall i b. a -> IxContT m o i b) -> IxContT m r o a) -> IxContT m r o a
 callCC f = shift (\k -> f (adapt k) >>>= k)
-	where
-		-- Both 'shift' and 'callCC' capture the current continuation up to the
-		-- containing 'reset'; but where 'shift' continuations "return" the
-		-- value "return"ed by the containing 'reset'-delimited computation,
-		-- 'callCC' continuations never "return" but instead cause the
-		-- containing 'reset' to "return" the captured continuation's result.
-		--
-		-- @adapt k x@ converts a 'shift'-style continuation to a
-		-- 'callCC'-style continuation by using its "return"ed value directly
-		-- as the final result.
-		--
-		-- @escape x@ ignores its continuation and provides x directly as the
-		-- result.
-		adapt k x = k x >>>= escape
-		escape x = IxContT (\_k -> return x)
+  where
+    -- Both 'shift' and 'callCC' capture the current continuation up to the
+    -- containing 'reset'; but where 'shift' continuations "return" the
+    -- value "return"ed by the containing 'reset'-delimited computation,
+    -- 'callCC' continuations never "return" but instead cause the
+    -- containing 'reset' to "return" the captured continuation's result.
+    --
+    -- @adapt k x@ converts a 'shift'-style continuation to a
+    -- 'callCC'-style continuation by using its "return"ed value directly
+    -- as the final result.
+    --
+    -- @escape x@ ignores its continuation and provides x directly as the
+    -- result.
+    adapt k x = k x >>>= escape
+    escape x = IxContT (\_k -> return x)
 
 instance Monad m => Functor (IxContT m i j) where
-	fmap = imap
+  fmap = imap
 
 instance Monad m => Pointed (IxContT m i i) where
-	point = ireturn
+  point = ireturn
 
 instance Monad m => Applicative (IxContT m i i) where
-	pure = ireturn
-	(<*>) = iap
+  pure = ireturn
+  (<*>) = iap
 
 instance Monad m => Monad (IxContT m i i) where
-	return = ireturn
-	m >>= k = ibind k m
+  return = ireturn
+  m >>= k = ibind k m
 
-instance Monad m => Cont.MonadCont (IxContT m i i) where 
-	-- GHC < 7.10 needs some hand-holding to specialize the 'forall' in the
-	-- continuation type.  Otherwise we'd just have:
-	--   callCC = callCC
-	callCC f = callCC (\k -> f k)
+instance Monad m => Cont.MonadCont (IxContT m i i) where
+  -- GHC < 7.10 needs some hand-holding to specialize the 'forall' in the
+  -- continuation type.  Otherwise we'd just have:
+  --   callCC = callCC
+  callCC f = callCC (\k -> f k)
 
 instance IxMonadTrans IxContT where
-	ilift m = IxContT (m >>=)
+  ilift m = IxContT (m >>=)
 
 instance MonadReader e m => MonadReader e (IxContT m i i) where
-	ask = ilift ask
-	local f m = IxContT $ \c -> do
-		r <- ask
-		local f (runIxContT m (local (const r) . c))
+  ask = ilift ask
+  local f m = IxContT $ \c -> do
+    r <- ask
+    local f (runIxContT m (local (const r) . c))
 
 instance MonadState e m => MonadState e (IxContT m i i) where
-	get = ilift get
-	put = ilift . put
+  get = ilift get
+  put = ilift . put
 
 instance MonadIO m => MonadIO (IxContT m i i) where
-	liftIO = ilift . liftIO 
+  liftIO = ilift . liftIO
 
-newtype IxCont r o a = IxCont (IxContT Identity r o a) 
-	deriving (IxFunctor, IxPointed, IxApplicative, IxMonad, IxMonadCont)
+newtype IxCont r o a = IxCont (IxContT Identity r o a)
+  deriving (IxFunctor, IxPointed, IxApplicative, IxMonad, IxMonadCont)
 
 
-runIxCont :: IxCont r o a -> (a -> o) -> r 
+runIxCont :: IxCont r o a -> (a -> o) -> r
 runIxCont (IxCont k) f = runIdentity $ runIxContT k (return . f)
 
 runIxCont_ :: IxCont r a a -> r
 runIxCont_ m = runIxCont m id
 
 instance Cont.MonadCont (IxCont i i) where
-	callCC f = IxCont (callCC (\q -> unwrapIxCont (f (IxCont . q))))
-		where unwrapIxCont (IxCont x) = x
+  callCC f = IxCont (callCC (\q -> unwrapIxCont (f (IxCont . q))))
+    where unwrapIxCont (IxCont x) = x
 
 instance Functor (IxCont i j) where
-	fmap = imap
+  fmap = imap
 
 instance Pointed (IxCont i i) where
-	point = ireturn
+  point = ireturn
 
 instance Applicative (IxCont i i) where
-	pure = ireturn
-	(<*>) = iap
+  pure = ireturn
+  (<*>) = iap
 
 instance Monad (IxCont i i) where
-	return = ireturn
-	m >>= k = ibind k m
+  return = ireturn
+  m >>= k = ibind k m
 

--- a/Control/Monad/Indexed/State.hs
+++ b/Control/Monad/Indexed/State.hs
@@ -5,17 +5,17 @@
 -- License     :  BSD-style (see the file LICENSE)
 --
 -- Maintainer  :  Reiner Pope <reiner.pope@gmail.com>
--- Stability   :  experimental 
+-- Stability   :  experimental
 -- Portability :  portable (although the MTL instances aren't!)
 --
 ----------------------------------------------------------------------------
-module Control.Monad.Indexed.State 
-	( IxMonadState(..)
-	, imodify
-	, igets
-	, IxStateT(..)
-	, IxState(..)
-	) where
+module Control.Monad.Indexed.State
+  ( IxMonadState(..)
+  , imodify
+  , igets
+  , IxStateT(..)
+  , IxState(..)
+  ) where
 
 import Control.Applicative
 import Data.Bifunctor
@@ -29,8 +29,8 @@ import Control.Monad.Cont
 import Control.Monad.Error.Class
 
 class IxMonad m => IxMonadState m where
-	iget :: m i i i
-	iput :: j -> m i j ()
+  iget :: m i i i
+  iput :: j -> m i j ()
 
 imodify :: IxMonadState m => (i -> j) -> m i j ()
 imodify f = iget >>>= iput . f
@@ -39,42 +39,42 @@ igets :: IxMonadState m => (i -> a) -> m i i a
 igets f = iget >>>= ireturn . f
 
 -- Indexed State Monad
-	
+
 newtype IxState i j a = IxState { runIxState :: i -> (a, j) }
 
 instance Functor (IxState i j) where
-	fmap = imap
+  fmap = imap
 
 instance IxFunctor IxState where
-	imap f m = IxState (first f . runIxState m)
+  imap f m = IxState (first f . runIxState m)
 
 instance IxPointed IxState where
-	ireturn = IxState . (,)
+  ireturn = IxState . (,)
 
 instance IxApplicative IxState where
-	iap = iapIxMonad
+  iap = iapIxMonad
 
 instance IxMonad IxState where
-	ibind f m = IxState $ \s1 -> let (a,s2) = runIxState m s1 in runIxState (f a) s2 
+  ibind f m = IxState $ \s1 -> let (a,s2) = runIxState m s1 in runIxState (f a) s2
 
 instance IxMonadState IxState where
-	iget = IxState (\x -> (x,x))
-	iput x = IxState (\_ -> ((),x))
+  iget = IxState (\x -> (x,x))
+  iput x = IxState (\_ -> ((),x))
 
-instance Bifunctor (IxState i) where 
-	bimap f g m = IxState $ bimap g f . runIxState m
+instance Bifunctor (IxState i) where
+  bimap f g m = IxState $ bimap g f . runIxState m
 
 instance Monad (IxState i i) where
-	return = ireturn
-	m >>= k = ibind k m 
+  return = ireturn
+  m >>= k = ibind k m
 
 instance Applicative (IxState i i) where
-	pure = ireturn
-	(<*>) = iap
+  pure = ireturn
+  (<*>) = iap
 
 instance MonadState i (IxState i i) where
-	get = iget
-	put = iput
+  get = iget
+  put = iput
 
 instance MonadFix (IxState i i) where
     mfix = imfix
@@ -88,73 +88,73 @@ instance IxMonadFix IxState where
 newtype IxStateT m i j a = IxStateT { runIxStateT :: i -> m (a, j) }
 
 instance Monad m => Functor (IxStateT m i j) where
-	fmap = imap
+  fmap = imap
 
 instance Monad m => IxFunctor (IxStateT m) where
-	imap f m = IxStateT $ \s -> runIxStateT m s >>= \(x,s') -> return (f x, s')
+  imap f m = IxStateT $ \s -> runIxStateT m s >>= \(x,s') -> return (f x, s')
 
 instance Monad m => IxPointed (IxStateT m) where
-    	ireturn a = IxStateT $ \s -> return (a, s)
+      ireturn a = IxStateT $ \s -> return (a, s)
 
 instance Monad m => IxApplicative (IxStateT m) where
-   	iap = iapIxMonad 
+     iap = iapIxMonad
 
 instance Monad m => IxMonad (IxStateT m) where
-    	ibind k m = IxStateT $ \s -> runIxStateT m s >>= \ ~(a, s') -> runIxStateT (k a) s'
+      ibind k m = IxStateT $ \s -> runIxStateT m s >>= \ ~(a, s') -> runIxStateT (k a) s'
 
 instance Monad m => Bifunctor (IxStateT m i) where
-	bimap f g m = IxStateT $ liftM (bimap g f) . runIxStateT m
+  bimap f g m = IxStateT $ liftM (bimap g f) . runIxStateT m
 
 instance Monad m => IxMonadState (IxStateT m) where
-	iget   = IxStateT $ \s -> return (s, s)
-	iput s = IxStateT $ \_ -> return ((), s)
+  iget   = IxStateT $ \s -> return (s, s)
+  iput s = IxStateT $ \_ -> return ((), s)
 
 instance MonadPlus m => IxMonadZero (IxStateT m) where
-	imzero = IxStateT $ const mzero
+  imzero = IxStateT $ const mzero
 
 instance MonadPlus m => IxMonadPlus (IxStateT m) where
-	m `implus` n = IxStateT $ \s -> runIxStateT m s `mplus` runIxStateT n s
+  m `implus` n = IxStateT $ \s -> runIxStateT m s `mplus` runIxStateT n s
 
 instance MonadFix m => IxMonadFix (IxStateT m) where
-	imfix f = IxStateT $ \s -> mfix $ \ ~(a, _) -> runIxStateT (f a) s
+  imfix f = IxStateT $ \s -> mfix $ \ ~(a, _) -> runIxStateT (f a) s
 
 instance MonadFix m => MonadFix (IxStateT m i i) where
-	mfix = imfix
+  mfix = imfix
 
 instance Monad m => Monad (IxStateT m i i) where
-	return = ireturn
-	m >>= k = ibind k m 
+  return = ireturn
+  m >>= k = ibind k m
 
 instance Monad m => Applicative (IxStateT m i i) where
-	pure = ireturn
-	(<*>) = iap
+  pure = ireturn
+  (<*>) = iap
 
 instance Monad m => MonadState i (IxStateT m i i) where
-	get = iget
-	put = iput
+  get = iget
+  put = iput
 
 instance IxMonadTrans IxStateT where
-	ilift m = IxStateT $ \s -> m >>= \a -> return (a, s)
+  ilift m = IxStateT $ \s -> m >>= \a -> return (a, s)
 
 instance MonadIO m => MonadIO (IxStateT m i i) where
-	liftIO = ilift . liftIO
+  liftIO = ilift . liftIO
 
 instance MonadReader r m => MonadReader r (IxStateT m i i) where
-	ask = ilift ask
-	local f m = IxStateT (local f . runIxStateT m)
+  ask = ilift ask
+  local f m = IxStateT (local f . runIxStateT m)
 
 instance MonadCont m => MonadCont (IxStateT m i i) where
-	callCC f = IxStateT $ \s -> callCC $ \k -> runIxStateT (f (\a -> IxStateT $ \s' -> k (a,s'))) s
+  callCC f = IxStateT $ \s -> callCC $ \k -> runIxStateT (f (\a -> IxStateT $ \s' -> k (a,s'))) s
 
 instance MonadError e m => MonadError e (IxStateT m i i) where
-	throwError = ilift . throwError
-	m `catchError` h = IxStateT $ \s -> runIxStateT m s `catchError` \e -> runIxStateT (h e) s
+  throwError = ilift . throwError
+  m `catchError` h = IxStateT $ \s -> runIxStateT m s `catchError` \e -> runIxStateT (h e) s
 
 instance MonadWriter w m => MonadWriter w (IxStateT m i i) where
-	tell = ilift . tell
-	listen m = IxStateT $ \s -> do 
-		~((a,s'),w) <- listen (runIxStateT m s)
-		return ((a,w),s')
-	pass m = IxStateT $ \s -> pass $ do
-		~((a,f),s') <- runIxStateT m s
-		return ((a,s'),f)
+  tell = ilift . tell
+  listen m = IxStateT $ \s -> do
+    ~((a,s'),w) <- listen (runIxStateT m s)
+    return ((a,w),s')
+  pass m = IxStateT $ \s -> pass $ do
+    ~((a,f),s') <- runIxStateT m s
+    return ((a,s'),f)

--- a/Control/Monad/Indexed/State.hs
+++ b/Control/Monad/Indexed/State.hs
@@ -9,6 +9,7 @@
 -- Portability :  portable (although the MTL instances aren't!)
 --
 ----------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
 module Control.Monad.Indexed.State
   ( IxMonadState(..)
   , imodify
@@ -17,7 +18,9 @@ module Control.Monad.Indexed.State
   , IxState(..)
   ) where
 
+#if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
+#endif
 import Data.Bifunctor
 import Control.Monad.Indexed
 import Control.Monad.Indexed.Trans


### PR DESCRIPTION
Also clean up some warnings in recent GHCs: 'tab characters' and 'unused import' due to Applicative in Prelude.