### PR TITLE
Allow build with ghc 9.8.2

### DIFF
--- a/Control/Monad/Indexed/Cont.hs
+++ b/Control/Monad/Indexed/Cont.hs
@@ -43,7 +43,7 @@ instance IxFunctor (IxContT m) where
   imap f m = IxContT $ \c -> runIxContT m (c . f)
 
 instance IxPointed (IxContT m) where
-  ireturn a = IxContT ($a)
+  ireturn a = IxContT ($ a)
 
 instance IxApplicative (IxContT m) where
   iap = iapIxMonad
@@ -84,7 +84,6 @@ instance Applicative (IxContT m i i) where
   (<*>) = iap
 
 instance Monad (IxContT m i i) where
-  return = ireturn
   m >>= k = ibind k m
 
 instance Monad m => Cont.MonadCont (IxContT m i i) where
@@ -134,6 +133,5 @@ instance Applicative (IxCont i i) where
   (<*>) = iap
 
 instance Monad (IxCont i i) where
-  return = ireturn
   m >>= k = ibind k m
 

--- a/Control/Monad/Indexed/State.hs
+++ b/Control/Monad/Indexed/State.hs
@@ -30,6 +30,8 @@ import Control.Monad.Writer
 import Control.Monad.Reader
 import Control.Monad.Cont
 import Control.Monad.Error.Class
+import Control.Monad.Fix (MonadFix(mfix))
+import Control.Monad (MonadPlus(mplus, mzero), liftM)
 
 class IxMonad m => IxMonadState m where
   iget :: m i i i
@@ -68,7 +70,6 @@ instance Bifunctor (IxState i) where
   bimap f g m = IxState $ bimap g f . runIxState m
 
 instance Monad (IxState i i) where
-  return = ireturn
   m >>= k = ibind k m
 
 instance Applicative (IxState i i) where
@@ -125,7 +126,6 @@ instance MonadFix m => MonadFix (IxStateT m i i) where
   mfix = imfix
 
 instance Monad m => Monad (IxStateT m i i) where
-  return = ireturn
   m >>= k = ibind k m
 
 instance Monad m => Applicative (IxStateT m i i) where

--- a/indexed-extras.cabal
+++ b/indexed-extras.cabal
@@ -6,10 +6,10 @@ License:             BSD3
 License-file:        LICENSE
 Author:              Edward A. Kmett
 Maintainer:          Reiner Pope <reiner.pope@gmail.com>
-Copyright:           
+Copyright:
     Copyright (C) 2012 Reiner Pope,
-    Copyright (C) 2008 Edward A. Kmett, 
-    Copyright (C) 2004--2008 Dave Menendez, 
+    Copyright (C) 2008 Edward A. Kmett,
+    Copyright (C) 2004--2008 Dave Menendez,
     Copyright (C) 2007 Iavor Diatchki
 Category:            Control
 Build-type:          Simple
@@ -28,9 +28,9 @@ Library
   Build-depends:
      base < 5,
      indexed < 0.2,
-     mtl < 2.3,
+     mtl < 2.4,
      pointed < 5.1,
-     bifunctors < 5.6
+     bifunctors < 5.7
   ghc-options:
      -Wall
   Extensions:


### PR DESCRIPTION
I think there is a dependency hell between `semigrupoids`, `bifunctors` and `kan-extensions` which disallow this library to be built with `ghc-9.8.2`. If I try `cabal build --allow-newer` I got a compiler error. Essentially `MonadFix` and `MonadPlus` type classes aren't in scope, so you have to explicitly add them. This PR also bumps bifunctors upper constraint and remove some deprecation warnings

Fix missing imports; remove return warnings; bump bifunctors